### PR TITLE
CI: Bump dir2uf2 and py_decl versions.

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -82,14 +82,14 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: gadgetoid/py_decl
-        ref: v0.0.2
+        ref: v0.0.3
         path: py_decl
         
     - name: "dir2uf2: Checkout"
       uses: actions/checkout@v4
       with:
         repository: gadgetoid/dir2uf2
-        ref: v0.0.7
+        ref: v0.0.8
         path: dir2uf2
 
     - name: "MicroPython: Build MPY Cross"


### PR DESCRIPTION
Stops completely broken UF2s being created for RP2350 boards.