### PR TITLE
RGB565 doc fixed to 5 blue bits

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -121,7 +121,7 @@ Then we chop them down to 5, 6 and 5 bits respectively:
 ```
 red = RRRRR
 green = GGGGGG
-blue = BBBBBB
+blue = BBBBB
 ```
 
 And stick them together:


### PR DESCRIPTION
The blue example accidentally had 6 bits instead of 5.